### PR TITLE
Profile support

### DIFF
--- a/src/ACMEServer.ADCS/Program.cs
+++ b/src/ACMEServer.ADCS/Program.cs
@@ -1,5 +1,4 @@
 using ACMEServer.Storage.FileSystem.Extensions;
-using Microsoft.Extensions.Configuration;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Th11s.ACMEServer.AspNetCore;

--- a/src/ACMEServer.ADCS/appsettings-sample.json
+++ b/src/ACMEServer.ADCS/appsettings-sample.json
@@ -103,7 +103,7 @@
     },
 
     "Default-Device": {
-      "SupportedIdentifiers": [ "persistet-identifier" ],
+      "SupportedIdentifiers": [ "permanent-identifier" ],
       "ADCSOptions": {
         "AllowCNSuffix": true,
         "AllowEmptyCN": true,

--- a/src/ACMEServer.ADCS/appsettings-sample.json
+++ b/src/ACMEServer.ADCS/appsettings-sample.json
@@ -44,7 +44,7 @@
 
   "AcmeServer": {
     "AuthorizationValidityPeriod": "23:59:59", // optional, the period of time, the authorization is valid. After this period, the authorization will be invalid and a new challenge must be requested.
-    
+
     "HostedWorkers": {
       "ValidationCheckInterval": 60, // In Seconds. Challenge validation will check for work after this period.
       "IssuanceCheckInterval": 60 // In Seconds. Certificate Issuance will check for work after this period.
@@ -65,7 +65,7 @@
       "MACRetrievalUrl": "https://myEABService.example.com/mac/{kid}", // required, URL to retrieve the MAC-Key from {kid}
 
       "SuccessSignalUrl": "https://myEABService.example.com/success/{kid}", // optional, URL to signal successful EAB check"
-      "FailedSignalUrl": "https://myEABService.example.com/failed/{kid}" // optional, URL to signal failed EAB check",
+      "FailedSignalUrl": "https://myEABService.example.com/failed/{kid}", // optional, URL to signal failed EAB check",
 
       "Headers": [
         {
@@ -75,6 +75,45 @@
       ]
     }
   },
+
+  // Issuance profile configuration - there's no default profile, you must define at least one.
+  "Profiles": {
+    // The profile name is used to identify the profile in the ACME-Server.
+    "Default-DNS": {
+      // List of supported identifiers for this profile.
+      "SupportedIdentifiers": [ "dns", "ip" ],
+
+      // The following settings are used to validate the identifiers.
+      "IdentifierValidation": {
+        // Configure DNS identifier validation
+        "DNS": {
+          // AllowedDNSNames is used to restrict the DNS names. It's an endsWith case-insensitive match.
+          // example.com will allow *.example.com and example.com, .example.com will allow *.example.com but not example.com
+          // The default is an empty string - so no restriction.
+          "AllowedDNSNames": [ "" ]
+        }
+      },
+
+      "ADCSOptions": {
+        "AllowCNSuffix": true,
+        "AllowEmptyCN": true,
+        "CAServer": "CA.FQDN.com\\CA Name",
+        "TemplateName": "DNS-ACME-Template"
+      }
+    },
+
+    "Default-Device": {
+      "SupportedIdentifiers": [ "persistet-identifier" ],
+      "ADCSOptions": {
+        "AllowCNSuffix": true,
+        "AllowEmptyCN": true,
+        "CAServer": "CA.FQDN.com\\CA Name",
+        "TemplateName": "Device-ACME-Template"
+      }
+    }
+  },
+  
+
 
   "AcmeFileStore": {
     "BasePath": "C:\\ACME-ADCS\\" // Make sure the path exists and is writeable from the ACME server process identity.

--- a/src/ACMEServer.ADCS/appsettings-sample.json
+++ b/src/ACMEServer.ADCS/appsettings-sample.json
@@ -1,5 +1,4 @@
 {
-  // Be aware, that JSON does not support comments.
   // This file is for reference only.
 
   // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/#configure-logging
@@ -22,51 +21,50 @@
   // If you run the software in a windows service, you'll need to configure Kestrel (the AspNetCore WebServer) directly.
   // see https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel#endpoint-configuration for further informations.
   "Kestrel": {
-    "Endpoints": {
-      "Https": {
-        "Url": "https://*:5004",
-        "Certificate": {
-          // Either use this settings for certificate store
-          "Subject": "<subject; required>",
-          "Store": "<certificate store; required>",
-          "Location": "<location; defaults to CurrentUser>",
-          "AllowInvalid": "<true or false; defaults to false>",
-
-          // Or this for file based pfx.
-          "Path": "<path to .pfx file>",
-          "Password": "<certificate password>"
-        }
-      }
-    }
+    /// ...
   },
 
   // The ACME Server configuration - questions? See https://github.com/glatzert/ACME-Server-ADCS/
-
   "AcmeServer": {
-    "AuthorizationValidityPeriod": "23:59:59", // optional, the period of time, the authorization is valid. After this period, the authorization will be invalid and a new challenge must be requested.
-
     "HostedWorkers": {
       "ValidationCheckInterval": 60, // In Seconds. Challenge validation will check for work after this period.
       "IssuanceCheckInterval": 60 // In Seconds. Certificate Issuance will check for work after this period.
     },
 
-    "WebsiteUrl": "https://my-custom.site", // Included in ACME-Metadata.
+    // [Optional] This url is included in the metadata - it's for humans to read.
+    "WebsiteUrl": "https://my-custom.site",
 
+    // [Optional] Terms of Service (TOS) - this is included in the ACME-Metadata.
     "TOS": {
-      "RequireAgreement": false, // If true, TOS-Agreement will be checked upon account usage.
 
+      // [Optional] For internal use most likely 'false'
+      "RequireAgreement": false,
+
+      // [Optional] The TOS-URL is included in the ACME-Metadata and error messages.
       "Url": "https://my-custom.tos", // Included in ACME-Metadata
-      "LastUpdate": "2020-01-23" // TOS-Agreement is time-based and must be repeated, if TOS changes.
+
+      // [Optional] TOS-Agreement is time-based and must be repeated, if TOS changes.
+      "LastUpdate": "2020-01-23"
     },
 
-    "ExternalAccountBinding": { // If this exists, services for EAB will be included
-      "Required": true, // If true, EAB is required for account creation.
 
-      "MACRetrievalUrl": "https://myEABService.example.com/mac/{kid}", // required, URL to retrieve the MAC-Key from {kid}
+    // [Optional] The ACME-Server supports external account binding (EAB) - this is included in the ACME-Metadata.
+    // if this section exists, the ACME-Server will configure itself to support EAB.
+    "ExternalAccountBinding": {
 
-      "SuccessSignalUrl": "https://myEABService.example.com/success/{kid}", // optional, URL to signal successful EAB check"
-      "FailedSignalUrl": "https://myEABService.example.com/failed/{kid}", // optional, URL to signal failed EAB check",
+      // [Required] If false, EAB is optional for account creation.
+      "Required": true,
 
+      // [Required] Url to retrieve the MAC-key for given {kid}
+      "MACRetrievalUrl": "https://myEABService.example.com/mac/{kid}",
+
+      // [Optional] Url to signal successful EAB check
+      "SuccessSignalUrl": "https://myEABService.example.com/success/{kid}",
+
+      // [Optional] Url to signal failed EAB check
+      "FailedSignalUrl": "https://myEABService.example.com/failed/{kid}",
+
+      // [Optional] Http-Headers to be sent to the MAC related URLs
       "Headers": [
         {
           "Key": "Authorization",
@@ -76,54 +74,57 @@
     }
   },
 
-  // Issuance profile configuration - there's no default profile, you must define at least one.
+
+  // [Required] Issuance profile configuration - there's no default profile, you must define at least one.
   "Profiles": {
+
     // The profile name is used to identify the profile in the ACME-Server.
     "Default-DNS": {
-      // List of supported identifiers for this profile.
+
+      // [Optional] The validity period of the authorization challenge. The default is one day.
+      // After this period, the authorization will be invalid and a new challenge must be requested.
+      "AuthorizationValidityPeriod": "23:59:59",
+
+      // [Required] List of supported identifiers for this profile.
+      // Possible valies are: dns, ip, permanent-identifier, hardware-module
       "SupportedIdentifiers": [ "dns", "ip" ],
 
-      // The following settings are used to validate the identifiers.
+      // [Optional] The following settings are used to validate the identifiers.
       "IdentifierValidation": {
-        // Configure DNS identifier validation
+
+        // [Optional] Configure DNS identifier validation
         "DNS": {
-          // AllowedDNSNames is used to restrict the DNS names. It's an endsWith case-insensitive match.
+
+          // [Optional] AllowedDNSNames is used to restrict the DNS names. It's an endsWith case-insensitive match.
           // example.com will allow *.example.com and example.com, .example.com will allow *.example.com but not example.com
           // The default is an empty string - so no restriction.
           "AllowedDNSNames": [ "" ]
         }
       },
 
+      // [Required] The following settings are used to issue the certificate.
       "ADCSOptions": {
-        "AllowCNSuffix": true,
-        "AllowEmptyCN": true,
+        // [Required] The CA-Server to use for certificate issuance.
         "CAServer": "CA.FQDN.com\\CA Name",
+
+        // [Required] The template to use for certificate issuance.
         "TemplateName": "DNS-ACME-Template"
       }
     },
 
+    // A sample for permanent-identifiers
     "Default-Device": {
       "SupportedIdentifiers": [ "permanent-identifier" ],
       "ADCSOptions": {
-        "AllowCNSuffix": true,
-        "AllowEmptyCN": true,
         "CAServer": "CA.FQDN.com\\CA Name",
         "TemplateName": "Device-ACME-Template"
       }
     }
   },
-  
 
 
+  // [Required] The ACME-FileStore configuration - this is used to store the ACME-Server data.
   "AcmeFileStore": {
     "BasePath": "C:\\ACME-ADCS\\" // Make sure the path exists and is writeable from the ACME server process identity.
-  },
-
-  "ADCSIssuer": {
-    "AllowEmptyCN": true, // If ture the Certificate CN will also be considered valid, if empty.
-    "AllowCNSuffix": true, // If true the Certificate CN will be checked to start with CN=<identifier>, but it may also contain additional information.
-
-    "CAServer": "ca-server.example.com\\CA Name Example", // Points to your CA-Server instance
-    "TemplateName": "ACME-Template" // Template to be used for certificate issuance
   }
 }

--- a/src/ACMEServer.ADCS/appsettings.Development.json
+++ b/src/ACMEServer.ADCS/appsettings.Development.json
@@ -4,17 +4,20 @@
       "Default": "Debug",
       "Microsoft": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
+    },
+
+    "PathFormat": "D:\\Temp\\ACME-ADCS\\Logs\\{Date}.json"
+  },
+
+  "AllowedHosts": "*",
+
+  "AcmeServer": {
+    "TOS": {
+      "RequireAgreement": false
     }
   },
 
   "AcmeFileStore": {
-    "BasePath": "C:\\ACME-ADCS\\"
-  },
-
-  "ADCSIssuer": {
-    "AllowCNSuffix": true,
-
-    "CAServer": "",
-    "TemplateName": "ACMEUser2020"
+    "BasePath": "D:\\Temp\\ACME-ADCS\\"
   }
 }

--- a/src/ACMEServer.ADCS/appsettings.json
+++ b/src/ACMEServer.ADCS/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Warning"
     },
@@ -24,10 +24,24 @@
     "BasePath": "C:\\ACME-ADCS\\"
   },
 
-  "ADCSIssuer": {
-    "AllowCNSuffix": true,
-    "AllowEmptyCN": true,
-    "CAServer": "CA.FQDN.com\\CA Name",
-    "TemplateName": "ACMETemplate"
+  "Profiles": {
+    "Default-DNS": {
+      "SupportedIdentifiers": [ "dns", "ip" ],
+      "ADCSOptions": {
+        "AllowCNSuffix": true,
+        "AllowEmptyCN": true,
+        "CAServer": "CA.FQDN.com\\CA Name",
+        "TemplateName": "DNS-ACME-Template"
+      }
+    },
+    "Default-Device": {
+      "SupportedIdentifiers": [ "persistet-identifier" ],
+      "ADCSOptions": {
+        "AllowCNSuffix": true,
+        "AllowEmptyCN": true,
+        "CAServer": "CA.FQDN.com\\CA Name",
+        "TemplateName": "Device-ACME-Template"
+      }
+    }
   }
 }

--- a/src/ACMEServer.ADCS/appsettings.json
+++ b/src/ACMEServer.ADCS/appsettings.json
@@ -35,7 +35,7 @@
       }
     },
     "Default-Device": {
-      "SupportedIdentifiers": [ "persistet-identifier" ],
+      "SupportedIdentifiers": [ "permanent-identifier" ],
       "ADCSOptions": {
         "AllowCNSuffix": true,
         "AllowEmptyCN": true,

--- a/src/ACMEServer.Abstractions/Services/ICertificateIssuer.cs
+++ b/src/ACMEServer.Abstractions/Services/ICertificateIssuer.cs
@@ -1,8 +1,9 @@
 ﻿using Th11s.ACMEServer.Model;
+using Th11s.ACMEServer.Model.Primitives;
 
 namespace Th11s.ACMEServer.Services;
 
 public interface ICertificateIssuer
 {
-    Task<(byte[]? Certificates, AcmeError? Error)> IssueCertificate(string csr, CancellationToken cancellationToken);
+    Task<(byte[]? Certificates, AcmeError? Error)> IssueCertificate(ProfileName profile, string csr, CancellationToken cancellationToken);
 }

--- a/src/ACMEServer.Abstractions/Services/IIssuanceProfileSelector.cs
+++ b/src/ACMEServer.Abstractions/Services/IIssuanceProfileSelector.cs
@@ -1,9 +1,10 @@
 ﻿using Th11s.ACMEServer.HttpModel;
+using Th11s.ACMEServer.Model.Primitives;
 
 namespace Th11s.ACMEServer.Services
 {
     public interface IIssuanceProfileSelector
     {
-        Task<ProfileDescriptor> SelectProfile(IEnumerable<Identifier> identifiers, string? profileName, CancellationToken cancellationToken);
+        Task<ProfileName> SelectProfile(IEnumerable<Identifier> identifiers, ProfileName profileName, CancellationToken cancellationToken);
     }
 }

--- a/src/ACMEServer.Abstractions/Services/IIssuanceProfileSelector.cs
+++ b/src/ACMEServer.Abstractions/Services/IIssuanceProfileSelector.cs
@@ -1,4 +1,4 @@
-﻿using Th11s.ACMEServer.HttpModel;
+﻿using Th11s.ACMEServer.Model;
 using Th11s.ACMEServer.Model.Primitives;
 
 namespace Th11s.ACMEServer.Services

--- a/src/ACMEServer.Abstractions/Services/IIssuanceProfileSelector.cs
+++ b/src/ACMEServer.Abstractions/Services/IIssuanceProfileSelector.cs
@@ -1,0 +1,9 @@
+﻿using Th11s.ACMEServer.HttpModel;
+
+namespace Th11s.ACMEServer.Services
+{
+    public interface IIssuanceProfileSelector
+    {
+        Task<ProfileDescriptor> SelectProfile(IEnumerable<Identifier> identifiers, string? profileName, CancellationToken cancellationToken);
+    }
+}

--- a/src/ACMEServer.CertProvider.ADCS/ADCSOptions.cs
+++ b/src/ACMEServer.CertProvider.ADCS/ADCSOptions.cs
@@ -1,7 +1,0 @@
-namespace Th11s.ACMEServer.CertProvider.ADCS;
-
-public class ADCSOptions
-{
-    public string CAServer { get; set; }
-    public string? TemplateName { get; set; }
-}

--- a/src/ACMEServer.CertProvider.ADCS/CertificateIssuer.cs
+++ b/src/ACMEServer.CertProvider.ADCS/CertificateIssuer.cs
@@ -16,10 +16,10 @@ public sealed class CertificateIssuer : ICertificateIssuer
     private const int CR_OUT_BASE64 = 0x1;
     private const int CR_OUT_CHAIN = 0x100;
 
-    private readonly IOptionsSnapshot<ProfileDescriptor> _options;
+    private readonly IOptionsSnapshot<ProfileConfiguration> _options;
     private readonly ILogger<CertificateIssuer> _logger;
 
-    public CertificateIssuer(IOptionsSnapshot<ProfileDescriptor> options, ILogger<CertificateIssuer> logger)
+    public CertificateIssuer(IOptionsSnapshot<ProfileConfiguration> options, ILogger<CertificateIssuer> logger)
     {
         _options = options;
         _logger = logger;

--- a/src/ACMEServer.CertProvider.ADCS/CertificateIssuer.cs
+++ b/src/ACMEServer.CertProvider.ADCS/CertificateIssuer.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 using Th11s.ACMEServer.Model;
+using Th11s.ACMEServer.Model.Configuration;
 using Th11s.ACMEServer.Services;
 using CertCli = CERTCLILib;
 

--- a/src/ACMEServer.CertProvider.ADCS/CsrValidator.cs
+++ b/src/ACMEServer.CertProvider.ADCS/CsrValidator.cs
@@ -2,6 +2,7 @@ using CERTENROLLLib;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Th11s.ACMEServer.Model;
+using Th11s.ACMEServer.Model.Configuration;
 using Th11s.ACMEServer.Services;
 
 namespace Th11s.ACMEServer.CertProvider.ADCS;

--- a/src/ACMEServer.CertProvider.ADCS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ACMEServer.CertProvider.ADCS/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Th11s.ACMEServer.Model.Configuration;
 using Th11s.ACMEServer.Services;
 

--- a/src/ACMEServer.CertProvider.ADCS/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ACMEServer.CertProvider.ADCS/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Th11s.ACMEServer.Model.Configuration;
 using Th11s.ACMEServer.Services;
 
 namespace Th11s.ACMEServer.CertProvider.ADCS.Extensions;

--- a/src/ACMEServer.Model/AcmeErrors.cs
+++ b/src/ACMEServer.Model/AcmeErrors.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using Th11s.ACMEServer.Model.Primitives;
 
 namespace Th11s.ACMEServer.Model;
 
@@ -176,4 +177,25 @@ public static class AcmeErrors
             $"{CustomUrn}:externalAccountBindingFailed",
             detail
             );
+
+
+    public static AcmeError NoIssuanceProfile()
+        => new(
+            $"{CustomUrn}:noIssuanceProfile",
+            "No issuance profile was found that supports the requested identifiers."
+            );
+
+    public static AcmeError UnsupportedProfile(ProfileName profileName)
+        => new AcmeError(
+            //TODO: Check if there is an official URN for this
+            $"{CustomUrn}:unsupportedIssuanceProfile",
+            $"The requested issuance profile {profileName} is not supported."
+            );
+
+    public static AcmeError InvalidProfile(ProfileName profileName)
+        => new(
+            //TODO: Check if there is an official URN for this
+            $"{CustomUrn}:invalidIssuanceProfile",
+            $"The requested issuance profile {profileName} is does not support all requested identifiers."
+        );
 }

--- a/src/ACMEServer.Model/Configuration/ADCSOptions.cs
+++ b/src/ACMEServer.Model/Configuration/ADCSOptions.cs
@@ -1,0 +1,7 @@
+namespace Th11s.ACMEServer.Model.Configuration;
+
+public class ADCSOptions
+{
+    public required string CAServer { get; set; }
+    public string? TemplateName { get; set; }
+}

--- a/src/ACMEServer.Model/Configuration/ADCSOptions.cs
+++ b/src/ACMEServer.Model/Configuration/ADCSOptions.cs
@@ -3,5 +3,5 @@ namespace Th11s.ACMEServer.Model.Configuration;
 public class ADCSOptions
 {
     public required string CAServer { get; set; }
-    public string? TemplateName { get; set; }
+    public required string? TemplateName { get; set; }
 }

--- a/src/ACMEServer.Model/Configuration/DNSValidationParameters.cs
+++ b/src/ACMEServer.Model/Configuration/DNSValidationParameters.cs
@@ -1,0 +1,14 @@
+﻿namespace Th11s.ACMEServer.Model.Configuration
+{
+    /// <summary>
+    /// Parameters for DNS validation.
+    /// </summary>
+    public class DNSValidationParameters
+    {
+        /// <summary>
+        /// The DNS names that are allowed for this profile, e.g. "example.com"
+        /// The values will be checked by using a case-insenstive, trimmed "EndsWith"
+        /// </summary>
+        public string[] AllowedDNSNames { get; set; } = [""];
+    }
+}

--- a/src/ACMEServer.Model/Configuration/IdentifierValidationParameters.cs
+++ b/src/ACMEServer.Model/Configuration/IdentifierValidationParameters.cs
@@ -1,0 +1,7 @@
+﻿namespace Th11s.ACMEServer.Model.Configuration
+{
+    public class IdentifierValidationParameters
+    {
+        public DNSValidationParameters DNS { get; set; } = new();
+    }
+}

--- a/src/ACMEServer.Model/Configuration/ProfileConfiguration.cs
+++ b/src/ACMEServer.Model/Configuration/ProfileConfiguration.cs
@@ -1,11 +1,13 @@
 ﻿namespace Th11s.ACMEServer.Model.Configuration
 {
-    public class ProfileDescriptor
+    public class ProfileConfiguration
     {
         public string Name { get; set; } = "";
 
         public required string[] SupportedIdentifiers { get; set; } = [];
 
         public required ADCSOptions ADCSOptions { get; set; }
+
+        public IdentifierValidationParameters IdentifierValidation { get; set; } = new ();
     }
 }

--- a/src/ACMEServer.Model/Configuration/ProfileConfiguration.cs
+++ b/src/ACMEServer.Model/Configuration/ProfileConfiguration.cs
@@ -4,6 +4,8 @@
     {
         public string Name { get; set; } = "";
 
+        public TimeSpan AuthorizationValidityPeriod { get; set; } = TimeSpan.FromDays(1);
+
         public required string[] SupportedIdentifiers { get; set; } = [];
 
         public required ADCSOptions ADCSOptions { get; set; }

--- a/src/ACMEServer.Model/Configuration/ProfileDescriptor.cs
+++ b/src/ACMEServer.Model/Configuration/ProfileDescriptor.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Th11s.ACMEServer.Model.Configuration
+﻿namespace Th11s.ACMEServer.Model.Configuration
 {
     public class ProfileDescriptor
     {

--- a/src/ACMEServer.Model/Configuration/ProfileDescriptor.cs
+++ b/src/ACMEServer.Model/Configuration/ProfileDescriptor.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Th11s.ACMEServer.Model.Configuration
+{
+    public class ProfileDescriptor
+    {
+        public string Name { get; set; } = "";
+
+        public required string[] SupportedIdentifiers { get; set; } = [];
+
+        public required ADCSOptions ADCSOptions { get; set; }
+    }
+}

--- a/src/ACMEServer.Model/Order.cs
+++ b/src/ACMEServer.Model/Order.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.Serialization;
 using Th11s.ACMEServer.Model.Extensions;
+using Th11s.ACMEServer.Model.Primitives;
 
 namespace Th11s.ACMEServer.Model;
 
@@ -21,8 +22,8 @@ public class Order : IVersioned, ISerializable
 
         AccountId = accountId;
 
-        Identifiers = new List<Identifier>(identifiers);
-        Authorizations = new List<Authorization>();
+        Identifiers = [.. identifiers];
+        Authorizations = [];
     }
 
     public Order(Account account, IEnumerable<Identifier> identifiers)
@@ -40,6 +41,8 @@ public class Order : IVersioned, ISerializable
     public DateTimeOffset? NotBefore { get; set; }
     public DateTimeOffset? NotAfter { get; set; }
     public DateTimeOffset? Expires { get; set; }
+
+    public ProfileName Profile { get; set; }
 
     public AcmeError? Error { get; set; }
 
@@ -99,6 +102,8 @@ public class Order : IVersioned, ISerializable
         NotAfter = info.TryGetValue<DateTimeOffset?>(nameof(NotAfter));
         Expires = info.TryGetValue<DateTimeOffset?>(nameof(Expires));
 
+        Profile = new ProfileName(info.TryGetValue<string>(nameof(Profile)) ?? string.Empty);
+
         Error = info.TryGetValue<AcmeError?>(nameof(Error));
         Version = info.GetInt64(nameof(Version));
 
@@ -124,6 +129,8 @@ public class Order : IVersioned, ISerializable
         info.AddValue(nameof(NotBefore), NotBefore);
         info.AddValue(nameof(NotAfter), NotAfter);
         info.AddValue(nameof(Expires), Expires);
+
+        info.AddValue(nameof(Profile), Profile.Value);
 
         info.AddValue(nameof(Error), Error);
         info.AddValue(nameof(Version), Version);

--- a/src/ACMEServer.Model/Primitives/ProfileName.cs
+++ b/src/ACMEServer.Model/Primitives/ProfileName.cs
@@ -1,0 +1,12 @@
+﻿namespace Th11s.ACMEServer.Model.Primitives;
+
+public readonly record struct ProfileName(string Value)
+{
+    public static implicit operator string(ProfileName accountId) => accountId.Value;
+    public static explicit operator ProfileName(string value) => new(value);
+
+    public override readonly string ToString() => Value;
+    public override readonly int GetHashCode() => HashCode.Combine(Value);
+
+    public static ProfileName None => new(string.Empty);
+}

--- a/src/ACMEServer/AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ACMEServer/AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -107,7 +107,7 @@ public static class ServiceCollectionExtensions
         foreach (var profile in profileSection)
         {
             profiles.Add(new ProfileName(profile.Key));
-            services.AddOptions<ProfileDescriptor>(profile.Key)
+            services.AddOptions<ProfileConfiguration>(profile.Key)
                 .BindConfiguration(profile.Path)
                 .Configure(p => p.Name = profile.Key);
         }

--- a/src/ACMEServer/AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ACMEServer/AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,8 @@ using Th11s.ACMEServer.AspNetCore.Authorization;
 using Th11s.ACMEServer.Configuration;
 using Th11s.ACMEServer.HostedServices;
 using Th11s.ACMEServer.Json;
+using Th11s.ACMEServer.Model.Configuration;
+using Th11s.ACMEServer.Model.Primitives;
 using Th11s.ACMEServer.RequestServices;
 using Th11s.ACMEServer.Services;
 using Th11s.ACMEServer.Services.ChallengeValidation;
@@ -75,6 +77,7 @@ public static class ServiceCollectionExtensions
         acmeServerConfig.Bind(acmeServerOptions);
 
         services.Configure<ACMEServerOptions>(acmeServerConfig);
+        services.ConfigureProfiles(configuration);
 
         if (configuration.GetSection($"{sectionName}:ExternalAccountBinding").Exists())
         {
@@ -87,6 +90,31 @@ public static class ServiceCollectionExtensions
         }
 
         services.ConfigureHttpJsonOptions(opt => opt.SerializerOptions.ApplyDefaultJsonSerializerOptions());
+
+        return services;
+    }
+
+
+    public static IServiceCollection ConfigureProfiles(this IServiceCollection services, IConfiguration configuration)
+    {
+        var profileSection = configuration.GetSection("Profiles")?.GetChildren();
+        if(profileSection?.Any() != true)
+        {
+            throw new ApplicationException("Could not find any profiles in configuration. Without profiles the server cannot provide any service.");
+        }
+
+        var profiles = new HashSet<ProfileName>();
+        foreach (var profile in profileSection)
+        {
+            profiles.Add(new ProfileName(profile.Key));
+            services.AddOptions<ProfileDescriptor>(profile.Key)
+                .BindConfiguration(profile.Path)
+                .Configure(p => p.Name = profile.Key);
+        }
+
+        // TODO: probably it's advisable to encapsulate this in a class
+        services.AddOptions<HashSet<ProfileName>>()
+            .Configure(p => p.UnionWith(profiles));
 
         return services;
     }

--- a/src/ACMEServer/AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ACMEServer/AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IOrderService, DefaultOrderService>();
         
         services.AddScoped<IOrderValidator, DefaultOrderValidator>();
+        services.AddScoped<IIssuanceProfileSelector, DefaultIssuanceProfileSelector>();
 
         services.AddScoped<IAuthorizationFactory, DefaultAuthorizationFactory>();
 

--- a/src/ACMEServer/Configuration/ACMEServerOptions.cs
+++ b/src/ACMEServer/Configuration/ACMEServerOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Th11s.ACMEServer.Configuration;
+﻿using Th11s.ACMEServer.Model.Configuration;
+
+namespace Th11s.ACMEServer.Configuration;
 
 public class ACMEServerOptions
 {

--- a/src/ACMEServer/Configuration/ACMEServerOptions.cs
+++ b/src/ACMEServer/Configuration/ACMEServerOptions.cs
@@ -12,7 +12,4 @@ public class ACMEServerOptions
     public TermsOfServiceOptions TOS { get; set; } = new ();
 
     public ExternalAccountBindingOptions? ExternalAccountBinding { get; set; }
-
-
-    public TimeSpan AuthorizationValidityPeriod { get; set; } = TimeSpan.FromDays(1);
 }

--- a/src/ACMEServer/Services/DefaultAuthorizationFactory.cs
+++ b/src/ACMEServer/Services/DefaultAuthorizationFactory.cs
@@ -1,16 +1,17 @@
 ﻿using Microsoft.Extensions.Options;
 using Th11s.ACMEServer.Configuration;
 using Th11s.ACMEServer.Model;
+using Th11s.ACMEServer.Model.Configuration;
 
 namespace Th11s.ACMEServer.Services;
 
 public class DefaultAuthorizationFactory(
     TimeProvider timeProvider,
-    IOptions<ACMEServerOptions> options
+    IOptionsSnapshot<ProfileConfiguration> options
     ) : IAuthorizationFactory
 {
     private readonly TimeProvider _timeProvider = timeProvider;
-    private readonly IOptions<ACMEServerOptions> _options = options;
+    private readonly IOptionsSnapshot<ProfileConfiguration> _options = options;
 
     public void CreateAuthorizations(Order order)
     {
@@ -19,7 +20,9 @@ public class DefaultAuthorizationFactory(
             throw new ArgumentNullException(nameof(order));
         }
 
-        var expiryDate = _timeProvider.GetUtcNow().Add(_options.Value.AuthorizationValidityPeriod);
+        var options = _options.Get(order.Profile);
+
+        var expiryDate = _timeProvider.GetUtcNow().Add(options.AuthorizationValidityPeriod);
         foreach (var identifier in order.Identifiers)
         {
             var authorization = new Authorization(order, identifier, expiryDate);

--- a/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
+++ b/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
@@ -7,15 +7,15 @@ namespace Th11s.ACMEServer.Services
 {
     public class DefaultIssuanceProfileSelector(
         IOptions<HashSet<ProfileName>> profiles, 
-        IOptionsSnapshot<ProfileDescriptor> profileDescriptors
+        IOptionsSnapshot<ProfileConfiguration> profileDescriptors
         ) : IIssuanceProfileSelector
     {
         private readonly IOptions<HashSet<ProfileName>> _profiles = profiles;
-        private readonly IOptionsSnapshot<ProfileDescriptor> _profileDescriptors = profileDescriptors;
+        private readonly IOptionsSnapshot<ProfileConfiguration> _profileDescriptors = profileDescriptors;
 
         public Task<ProfileName> SelectProfile(IEnumerable<Identifier> identifiers, ProfileName profileName, CancellationToken cancellationToken)
         {
-            ProfileDescriptor[] candidates =
+            ProfileConfiguration[] candidates =
                 profileName == ProfileName.None
                     ? [.. GetCandidates(identifiers)]
                     : [.. GetCandidate(profileName, identifiers)];
@@ -32,7 +32,7 @@ namespace Th11s.ACMEServer.Services
             return Task.FromResult(new ProfileName(result.Name));
         }
 
-        private IEnumerable<ProfileDescriptor> GetCandidates(IEnumerable<Identifier> identifiers)
+        private IEnumerable<ProfileConfiguration> GetCandidates(IEnumerable<Identifier> identifiers)
         {
             var profileNames = _profiles.Value;
 
@@ -47,7 +47,7 @@ namespace Th11s.ACMEServer.Services
             }
         }
 
-        private IEnumerable<ProfileDescriptor> GetCandidate(ProfileName profileName, IEnumerable<Identifier> identifiers)
+        private IEnumerable<ProfileConfiguration> GetCandidate(ProfileName profileName, IEnumerable<Identifier> identifiers)
         {
             var profileDescriptor = _profileDescriptors.Get(profileName) 
                 ?? throw AcmeErrors.UnsupportedProfile(profileName).AsException();
@@ -61,7 +61,7 @@ namespace Th11s.ACMEServer.Services
         }
 
 
-        private static bool DoesSupportAllIdentifiers(ProfileDescriptor profileDescriptor, IEnumerable<Identifier> identifiers)
+        private static bool DoesSupportAllIdentifiers(ProfileConfiguration profileDescriptor, IEnumerable<Identifier> identifiers)
         {
             return identifiers.All(i => profileDescriptor.SupportedIdentifiers.Contains(i.Type));
         }

--- a/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
+++ b/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
@@ -1,13 +1,69 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Microsoft.Extensions.Options;
+using System.Text.RegularExpressions;
+using Th11s.ACMEServer.HttpModel;
+using Th11s.ACMEServer.Model.Configuration;
+using Th11s.ACMEServer.Model.Primitives;
 
 namespace Th11s.ACMEServer.Services
 {
-    public class DefaultIssuanceProfileSelector : IIssuanceProfileSelector
+    public class DefaultIssuanceProfileSelector(
+        IOptions<HashSet<ProfileName>> profiles, 
+        IOptionsSnapshot<ProfileDescriptor> profileDescriptors
+        ) : IIssuanceProfileSelector
     {
+        private readonly IOptions<HashSet<ProfileName>> _profiles = profiles;
+        private readonly IOptionsSnapshot<ProfileDescriptor> _profileDescriptors = profileDescriptors;
 
+        public Task<ProfileName> SelectProfile(IEnumerable<Identifier> identifiers, ProfileName profileName, CancellationToken cancellationToken)
+        {
+            var profiles = _profiles.Value;
+
+            var candidates = 
+                profileName == ProfileName.None
+                    ? GetCandidate(profileName, identifiers).ToArray()
+                    : GetCandidates(identifiers).ToArray();
+
+            if (candidates.Count() == 0)
+            {
+                throw Model.AcmeErrors.NoIssuanceProfile().AsException();
+            }
+
+            // TODO: Rank the candidates
+            return Task.FromResult(candidates.First())
+        }
+
+        private IEnumerable<ProfileDescriptor> GetCandidates(IEnumerable<Identifier> identifiers)
+        {
+            var profileNames = _profiles.Value;
+
+            foreach(var profileName in profileNames)
+            {
+                var profileDescriptor = _profileDescriptors.Get(profileName);
+                
+                if (DoesSupportAllIdentifiers(profileDescriptor, identifiers))
+                {
+                    yield return profileDescriptor;
+                }
+            }
+        }
+
+        private IEnumerable<ProfileDescriptor> GetCandidate(ProfileName profileName, IEnumerable<Identifier> identifiers)
+        {
+            var profileDescriptor = _profileDescriptors.Get(profileName) 
+                ?? throw Model.AcmeErrors.UnsupportedProfile(profileName).AsException();
+
+            if (DoesSupportAllIdentifiers(profileDescriptor, identifiers))
+            {
+                throw Model.AcmeErrors.InvalidProfile(profileName).AsException();
+            }
+
+            return [profileDescriptor];
+        }
+
+
+        private bool DoesSupportAllIdentifiers(ProfileDescriptor profileDescriptor, IEnumerable<Identifier> identifiers)
+        {
+            return identifiers.All(i => profileDescriptor.SupportedIdentifiers.Contains(i.Type));
+        }
     }
 }

--- a/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
+++ b/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
@@ -16,10 +16,10 @@ namespace Th11s.ACMEServer.Services
 
         public Task<ProfileName> SelectProfile(IEnumerable<Identifier> identifiers, ProfileName profileName, CancellationToken cancellationToken)
         {
-            ProfileDescriptor[] candidates = 
+            ProfileDescriptor[] candidates =
                 profileName == ProfileName.None
-                    ? [.. GetCandidate(profileName, identifiers)]
-                    : [.. GetCandidates(identifiers)];
+                    ? [.. GetCandidates(identifiers)]
+                    : [.. GetCandidate(profileName, identifiers)];
 
             if (candidates.Length == 0)
             {
@@ -50,7 +50,7 @@ namespace Th11s.ACMEServer.Services
             var profileDescriptor = _profileDescriptors.Get(profileName) 
                 ?? throw AcmeErrors.UnsupportedProfile(profileName).AsException();
 
-            if (DoesSupportAllIdentifiers(profileDescriptor, identifiers))
+            if (!DoesSupportAllIdentifiers(profileDescriptor, identifiers))
             {
                 throw AcmeErrors.InvalidProfile(profileName).AsException();
             }

--- a/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
+++ b/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Th11s.ACMEServer.Services
+{
+    public class DefaultIssuanceProfileSelector : IIssuanceProfileSelector
+    {
+
+    }
+}

--- a/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
+++ b/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Options;
-using System.Text.RegularExpressions;
 using Th11s.ACMEServer.Model;
 using Th11s.ACMEServer.Model.Configuration;
 using Th11s.ACMEServer.Model.Primitives;
@@ -26,8 +25,11 @@ namespace Th11s.ACMEServer.Services
                 throw AcmeErrors.NoIssuanceProfile().AsException();
             }
 
-            // TODO: Rank the candidates
-            return Task.FromResult(new ProfileName(candidates[0].Name));
+            var result = candidates
+                .OrderBy(x => x.SupportedIdentifiers.Length) // Ordering by the number of supported identifiers, so we'll get the most specific one first
+                .First();
+            
+            return Task.FromResult(new ProfileName(result.Name));
         }
 
         private IEnumerable<ProfileDescriptor> GetCandidates(IEnumerable<Identifier> identifiers)

--- a/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
+++ b/src/ACMEServer/Services/DefaultIssuanceProfileSelector.cs
@@ -29,7 +29,7 @@ namespace Th11s.ACMEServer.Services
             }
 
             // TODO: Rank the candidates
-            return Task.FromResult(candidates.First())
+            return Task.FromResult(new ProfileName(candidates.First().Name));
         }
 
         private IEnumerable<ProfileDescriptor> GetCandidates(IEnumerable<Identifier> identifiers)

--- a/src/ACMEServer/Services/DefaultOrderService.cs
+++ b/src/ACMEServer/Services/DefaultOrderService.cs
@@ -50,7 +50,7 @@ public class DefaultOrderService(
             throw validationResult.Error.AsException();
         }
 
-        order.Profile = _issuanceProfileSelector.SelectProfile(identifiers, ProfileName.None, cancellationToken);
+        order.Profile = await _issuanceProfileSelector.SelectProfile(identifiers, ProfileName.None, cancellationToken);
 
         _authorizationFactory.CreateAuthorizations(order);
 

--- a/src/ACMEServer/Services/DefaultOrderService.cs
+++ b/src/ACMEServer/Services/DefaultOrderService.cs
@@ -44,13 +44,15 @@ public class DefaultOrderService(
             NotAfter = payload.NotAfter
         };
 
+        order.Profile = await _issuanceProfileSelector.SelectProfile(identifiers, ProfileName.None, cancellationToken);
+
+
         var validationResult = await _orderValidator.ValidateOrderAsync(order, cancellationToken);
         if (!validationResult.IsValid)
         {
             throw validationResult.Error.AsException();
         }
 
-        order.Profile = await _issuanceProfileSelector.SelectProfile(identifiers, ProfileName.None, cancellationToken);
 
         _authorizationFactory.CreateAuthorizations(order);
 

--- a/src/ACMEServer/Services/DefaultOrderService.cs
+++ b/src/ACMEServer/Services/DefaultOrderService.cs
@@ -1,5 +1,6 @@
 ﻿using Th11s.ACMEServer.Model;
 using Th11s.ACMEServer.Model.Exceptions;
+using Th11s.ACMEServer.Model.Primitives;
 using Th11s.ACMEServer.Model.Storage;
 using Th11s.ACMEServer.Services.Processors;
 using Payloads = Th11s.ACMEServer.HttpModel.Payloads;
@@ -8,6 +9,7 @@ namespace Th11s.ACMEServer.Services;
 
 public class DefaultOrderService(
     IOrderStore orderStore,
+    IIssuanceProfileSelector issuanceProfileSelector,
     IOrderValidator orderValidator,
     IAuthorizationFactory authorizationFactory,
     ICSRValidator csrValidator,
@@ -16,6 +18,7 @@ public class DefaultOrderService(
     ) : IOrderService
 {
     private readonly IOrderStore _orderStore = orderStore;
+    private readonly IIssuanceProfileSelector _issuanceProfileSelector = issuanceProfileSelector;
     private readonly IOrderValidator _orderValidator = orderValidator;
     private readonly IAuthorizationFactory _authorizationFactory = authorizationFactory;
     private readonly ICSRValidator _csrValidator = csrValidator;
@@ -46,6 +49,8 @@ public class DefaultOrderService(
         {
             throw validationResult.Error.AsException();
         }
+
+        order.Profile = _issuanceProfileSelector.SelectProfile(identifiers, ProfileName.None, cancellationToken);
 
         _authorizationFactory.CreateAuthorizations(order);
 

--- a/src/ACMEServer/Services/DefaultOrderValidator.cs
+++ b/src/ACMEServer/Services/DefaultOrderValidator.cs
@@ -1,11 +1,14 @@
-﻿using System.Net;
+﻿using Microsoft.Extensions.Options;
+using System.Net;
 using System.Text.RegularExpressions;
 using Th11s.ACMEServer.Model;
+using Th11s.ACMEServer.Model.Configuration;
 
 namespace Th11s.ACMEServer.Services
 {
-    public class DefaultOrderValidator : IOrderValidator
+    public class DefaultOrderValidator(IOptionsSnapshot<ProfileConfiguration> options) : IOrderValidator
     {
+        // TODO: This list should be syntesized from the ProfileConfiguration
         public static readonly HashSet<string> ValidIdentifierTypes = [
             IdentifierTypes.DNS,                  // RFC 8555 https://www.rfc-editor.org/rfc/rfc8555#section-9.7.7
             IdentifierTypes.IP,                   // RFC 8738 https://www.rfc-editor.org/rfc/rfc8738
@@ -13,10 +16,13 @@ namespace Th11s.ACMEServer.Services
             // "permanent-identifier", // https://www.ietf.org/archive/id/draft-acme-device-attest-03.html
             // "hardware-module",      // https://www.ietf.org/archive/id/draft-acme-device-attest-03.html
         ];
+        private readonly IOptionsSnapshot<ProfileConfiguration> _options = options;
 
         public async Task<AcmeValidationResult> ValidateOrderAsync(Order order, CancellationToken cancellationToken)
         {
-            var identifierValidationResult = await ValidateIdentifiersAsync(order.Identifiers, cancellationToken);
+            var profileConfig = _options.Get(order.Profile);
+
+            var identifierValidationResult = await ValidateIdentifiersAsync(order.Identifiers, profileConfig, cancellationToken);
 
             if(identifierValidationResult.Values.Any(x => !x.IsValid))
             {
@@ -30,7 +36,10 @@ namespace Th11s.ACMEServer.Services
             return AcmeValidationResult.Success();
         }
 
-        private Task<IDictionary<Identifier, AcmeValidationResult>> ValidateIdentifiersAsync(List<Identifier> identifiers, CancellationToken cancellationToken)
+        private Task<IDictionary<Identifier, AcmeValidationResult>> ValidateIdentifiersAsync(
+            List<Identifier> identifiers, 
+            ProfileConfiguration profileConfig, 
+            CancellationToken cancellationToken)
         {
             var result = new Dictionary<Identifier, AcmeValidationResult>();
 
@@ -44,7 +53,7 @@ namespace Th11s.ACMEServer.Services
 
                 if (identifier.Type == IdentifierTypes.DNS)
                 {
-                    result[identifier] = IsValidDNSIdentifier(identifier)
+                    result[identifier] = IsValidDNSIdentifier(identifier, profileConfig.IdentifierValidation.DNS)
                         ? AcmeValidationResult.Success()
                         : AcmeValidationResult.Failed(AcmeErrors.MalformedRequest($"The identifier value {identifier.Value} is not a valid DNS identifier."));
                 }
@@ -63,14 +72,19 @@ namespace Th11s.ACMEServer.Services
             return Task.FromResult((IDictionary<Identifier, AcmeValidationResult>)result);
         }
 
-        private static bool IsValidDNSIdentifier(Identifier identifier)
+        private static bool IsValidDNSIdentifier(Identifier identifier, DNSValidationParameters dnsParameters)
         {
             // RFC 1035 Section 2.3.1 https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1
             const string dnsLabelRegex = @"^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$";
 
-            return !string.IsNullOrEmpty(identifier.Value) &&
+            var isValidRFC1035DnsName = !string.IsNullOrEmpty(identifier.Value) &&
                    identifier.Value.Length <= 255 &&
                    identifier.Value.Split('.').All(part => Regex.IsMatch(part, dnsLabelRegex));
+
+            var isAllowedName = dnsParameters.AllowedDNSNames
+                .Any(x => identifier.Value.EndsWith(x, StringComparison.InvariantCultureIgnoreCase));
+
+            return isValidRFC1035DnsName && isAllowedName;
         }
 
         private static bool IsValidIPIdentifier(Identifier identifier)

--- a/src/ACMEServer/Services/Processors/CertificateIssuanceProcessor.cs
+++ b/src/ACMEServer/Services/Processors/CertificateIssuanceProcessor.cs
@@ -95,7 +95,7 @@ public sealed class CertificateIssuanceProcessor(
 
     private static async Task IssueCertificate(Order order, ICertificateIssuer certificateIssuer, IOrderStore orderStore, CancellationToken cancellationToken)
     {
-        var (certificate, error) = await certificateIssuer.IssueCertificate(order.CertificateSigningRequest!, cancellationToken);
+        var (certificate, error) = await certificateIssuer.IssueCertificate(order.Profile, order.CertificateSigningRequest!, cancellationToken);
 
         if (certificate == null)
         {

--- a/tests/ACME.CertProvider.ADCS.Tests.Manual/Program.cs
+++ b/tests/ACME.CertProvider.ADCS.Tests.Manual/Program.cs
@@ -1,97 +1,97 @@
-﻿using Microsoft.Extensions.Logging.Abstractions;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using Th11s.ACMEServer.CertProvider.ADCS;
-using Th11s.ACMEServer.Model;
-using Th11s.ACMEServer.Model.Configuration;
+﻿//using Microsoft.Extensions.Logging.Abstractions;
+//using System.Security.Cryptography;
+//using System.Security.Cryptography.X509Certificates;
+//using System.Text;
+//using Th11s.ACMEServer.CertProvider.ADCS;
+//using Th11s.ACMEServer.Model;
+//using Th11s.ACMEServer.Model.Configuration;
 
-if (args.Length <= 1)
-{
-    Console.WriteLine("Useage: ACME.CertProvider.ACDS.Tests.Manual.exe CSRValidation");
-    Console.WriteLine("Useage: ACME.CertProvider.ACDS.Tests.Manual.exe Issuance \"<CAConfig>\" \"<CertTemplate>\" \"<DNSName>\"");
-}
+//if (args.Length <= 1)
+//{
+//    Console.WriteLine("Useage: ACME.CertProvider.ACDS.Tests.Manual.exe CSRValidation");
+//    Console.WriteLine("Useage: ACME.CertProvider.ACDS.Tests.Manual.exe Issuance \"<CAConfig>\" \"<CertTemplate>\" \"<DNSName>\"");
+//}
 
-if (args[0] == "CSRValidation")
-{
-    await ManualCSRValidationTest();
-}
-else if (args[0] == "Issuance")
-{
-    await ManualIssuanceTest(args);
-}
+//if (args[0] == "CSRValidation")
+//{
+//    await ManualCSRValidationTest();
+//}
+//else if (args[0] == "Issuance")
+//{
+//    await ManualIssuanceTest(args);
+//}
 
 Console.ReadLine();
 
-async Task ManualCSRValidationTest()
-{
-    var base64Csr = "";
+//async Task ManualCSRValidationTest()
+//{
+//    var base64Csr = "";
 
-    var adcsOptions = new Microsoft.Extensions.Options.OptionsWrapper<ADCSOptions>(
-        new ADCSOptions
-        {
-            CAServer = "",
-            TemplateName = ""
-        });
+//    var adcsOptions = new Microsoft.Extensions.Options.OptionsWrapper<ADCSOptions>(
+//        new ADCSOptions
+//        {
+//            CAServer = "",
+//            TemplateName = ""
+//        });
 
-    var csrValidator = new CSRValidator(adcsOptions, new NullLogger<CSRValidator>());
+//    var csrValidator = new CSRValidator(adcsOptions, new NullLogger<CSRValidator>());
 
-    var validationResult = await csrValidator.ValidateCsrAsync(
-        new Order("FakeAccountId", [new Identifier("dns", "www.test.uni-mainz.de")]),
-        base64Csr,
-        default
-    );
-}
+//    var validationResult = await csrValidator.ValidateCsrAsync(
+//        new Order("FakeAccountId", [new Identifier("dns", "www.test.uni-mainz.de")]),
+//        base64Csr,
+//        default
+//    );
+//}
 
-async Task ManualIssuanceTest(string[] args)
-{
-    if (args.Length != 3)
-    {
-        Console.WriteLine("Useage: ACME.CertProvider.ACDS.Tests.Manual.exe Issuance \"<CAConfig>\" \"<CertTemplate>\" \"<DNSName>\"");
-        return;
-    }
+//async Task ManualIssuanceTest(string[] args)
+//{
+//    if (args.Length != 3)
+//    {
+//        Console.WriteLine("Useage: ACME.CertProvider.ACDS.Tests.Manual.exe Issuance \"<CAConfig>\" \"<CertTemplate>\" \"<DNSName>\"");
+//        return;
+//    }
 
-    var caConfig = args[0];
-    var caTemplate = args[1];
-    var dnsName = args[2];
+//    var caConfig = args[0];
+//    var caTemplate = args[1];
+//    var dnsName = args[2];
 
-    var subjectName = $"CN={dnsName}";
+//    var subjectName = $"CN={dnsName}";
 
-    var csp = RSA.Create(2048);
-    var csr = new CertificateRequest(subjectName, csp, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+//    var csp = RSA.Create(2048);
+//    var csr = new CertificateRequest(subjectName, csp, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 
-    var sanBuilder = new SubjectAlternativeNameBuilder();
-    sanBuilder.AddDnsName(dnsName);
-    csr.CertificateExtensions.Add(sanBuilder.Build());
+//    var sanBuilder = new SubjectAlternativeNameBuilder();
+//    sanBuilder.AddDnsName(dnsName);
+//    csr.CertificateExtensions.Add(sanBuilder.Build());
 
-    var csrBytes = csr.CreateSigningRequest();
-    var csrPEM = $"{Convert.ToBase64String(csrBytes)}";
+//    var csrBytes = csr.CreateSigningRequest();
+//    var csrPEM = $"{Convert.ToBase64String(csrBytes)}";
 
-    var acdsOptions = new Microsoft.Extensions.Options.OptionsWrapper<ADCSOptions>(
-        new ADCSOptions
-        {
-            CAServer = caConfig,
-            TemplateName = caTemplate
-        });
+//    var acdsOptions = new Microsoft.Extensions.Options.OptionsWrapper<ADCSOptions>(
+//        new ADCSOptions
+//        {
+//            CAServer = caConfig,
+//            TemplateName = caTemplate
+//        });
 
-    var issuer = new CertificateIssuer(acdsOptions, new NullLogger<CertificateIssuer>());
-    var (Certificates, Error) = await issuer.IssueCertificate(csrPEM, default);
+//    var issuer = new CertificateIssuer(acdsOptions, new NullLogger<CertificateIssuer>());
+//    var (Certificates, Error) = await issuer.IssueCertificate(csrPEM, default);
 
-    if (Error != null || Certificates == null)
-    {
-        Console.WriteLine(Error?.Detail ?? "Certificate was null, but there was no Error");
-        return;
-    }
+//    if (Error != null || Certificates == null)
+//    {
+//        Console.WriteLine(Error?.Detail ?? "Certificate was null, but there was no Error");
+//        return;
+//    }
 
-    var certificateCollection = new X509Certificate2Collection();
-    certificateCollection.Import(Certificates);
+//    var certificateCollection = new X509Certificate2Collection();
+//    certificateCollection.Import(Certificates);
 
-    var stringBuilder = new StringBuilder();
-    foreach (var certificate in certificateCollection)
-    {
-        var certPem = PemEncoding.Write("CERTIFICATE", certificate.Export(X509ContentType.Cert));
-        stringBuilder.AppendLine(new string(certPem));
-    }
+//    var stringBuilder = new StringBuilder();
+//    foreach (var certificate in certificateCollection)
+//    {
+//        var certPem = PemEncoding.Write("CERTIFICATE", certificate.Export(X509ContentType.Cert));
+//        stringBuilder.AppendLine(new string(certPem));
+//    }
 
-    Console.WriteLine(stringBuilder.ToString());
-}
+//    Console.WriteLine(stringBuilder.ToString());
+//}

--- a/tests/ACME.CertProvider.ADCS.Tests.Manual/Program.cs
+++ b/tests/ACME.CertProvider.ADCS.Tests.Manual/Program.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Th11s.ACMEServer.CertProvider.ADCS;
 using Th11s.ACMEServer.Model;
+using Th11s.ACMEServer.Model.Configuration;
 
 if (args.Length <= 1)
 {

--- a/tests/ACME.CertProvider.ADCS.Tests/CSRValidationTests.cs
+++ b/tests/ACME.CertProvider.ADCS.Tests/CSRValidationTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Th11s.ACMEServer.Model;
 using Th11s.ACMEServer.CertProvider.ADCS;
+using Th11s.ACMEServer.Model.Configuration;
 
 namespace ACME.CertProvider.ADCS.Tests;
 
@@ -13,6 +14,12 @@ namespace ACME.CertProvider.ADCS.Tests;
 /// </summary>
 public class CSRValidationTests
 {
+    private readonly ADCSOptions _options = new()
+    {
+        CAServer = "CA\\SERVER",
+        TemplateName = "Template"
+    };
+
     [Fact]
     public async Task CSR_And_Order_Match()
     {
@@ -46,7 +53,7 @@ public class CSRValidationTests
             """;
 
 
-        var sut = new CSRValidator(Options.Create(new ADCSOptions()), NullLogger<CSRValidator>.Instance);
+        var sut = new CSRValidator(Options.Create(_options), NullLogger<CSRValidator>.Instance);
         var result = await sut.ValidateCsrAsync(order, csr, default);
 
         Assert.True(result.IsValid);
@@ -84,7 +91,7 @@ public class CSRValidationTests
             """;
 
 
-        var sut = new CSRValidator(Options.Create(new ADCSOptions()), NullLogger<CSRValidator>.Instance);
+        var sut = new CSRValidator(Options.Create(_options), NullLogger<CSRValidator>.Instance);
         var result = await sut.ValidateCsrAsync(order, csr, default);
 
         Assert.False(result.IsValid);
@@ -120,7 +127,7 @@ public class CSRValidationTests
             """;
 
 
-        var sut = new CSRValidator(Options.Create(new ADCSOptions()), NullLogger<CSRValidator>.Instance);
+        var sut = new CSRValidator(Options.Create(_options), NullLogger<CSRValidator>.Instance);
         var result = await sut.ValidateCsrAsync(order, csr, default);
 
         Assert.False(result.IsValid);
@@ -155,7 +162,7 @@ public class CSRValidationTests
             """;
 
 
-        var sut = new CSRValidator(Options.Create(new ADCSOptions()), NullLogger<CSRValidator>.Instance);
+        var sut = new CSRValidator(Options.Create(_options), NullLogger<CSRValidator>.Instance);
         var result = await sut.ValidateCsrAsync(order, csr, default);
 
         Assert.True(result.IsValid);
@@ -191,7 +198,7 @@ public class CSRValidationTests
             """;
 
 
-        var sut = new CSRValidator(Options.Create(new ADCSOptions()), NullLogger<CSRValidator>.Instance);
+        var sut = new CSRValidator(Options.Create(_options), NullLogger<CSRValidator>.Instance);
         var result = await sut.ValidateCsrAsync(order, csr, default);
 
         Assert.True(result.IsValid);
@@ -227,7 +234,7 @@ public class CSRValidationTests
             """;
 
 
-        var sut = new CSRValidator(Options.Create(new ADCSOptions()), NullLogger<CSRValidator>.Instance);
+        var sut = new CSRValidator(Options.Create(_options), NullLogger<CSRValidator>.Instance);
         var result = await sut.ValidateCsrAsync(order, csr, default);
 
         Assert.True(result.IsValid);
@@ -263,7 +270,7 @@ public class CSRValidationTests
             """;
 
 
-        var sut = new CSRValidator(Options.Create(new ADCSOptions()), NullLogger<CSRValidator>.Instance);
+        var sut = new CSRValidator(Options.Create(_options), NullLogger<CSRValidator>.Instance);
         var result = await sut.ValidateCsrAsync(order, csr, default);
 
         Assert.False(result.IsValid);
@@ -299,7 +306,7 @@ public class CSRValidationTests
             """;
 
 
-        var sut = new CSRValidator(Options.Create(new ADCSOptions()), NullLogger<CSRValidator>.Instance);
+        var sut = new CSRValidator(Options.Create(_options), NullLogger<CSRValidator>.Instance);
         var result = await sut.ValidateCsrAsync(order, csr, default);
 
         Assert.False(result.IsValid);
@@ -333,7 +340,7 @@ public class CSRValidationTests
             """;
 
 
-        var sut = new CSRValidator(Options.Create(new ADCSOptions()), NullLogger<CSRValidator>.Instance);
+        var sut = new CSRValidator(Options.Create(_options), NullLogger<CSRValidator>.Instance);
         var result = await sut.ValidateCsrAsync(order, csr, default);
 
         Assert.True(result.IsValid);

--- a/tests/ACMEServer.Tests/FakeOptionSnapshot.cs
+++ b/tests/ACMEServer.Tests/FakeOptionSnapshot.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace Th11s.AcmeServer.Tests
+{
+    public class FakeOptionSnapshot<T> : IOptionsSnapshot<T>
+        where T : class
+    {
+        private readonly IDictionary<string, T> _values;
+
+        public FakeOptionSnapshot(IDictionary<string, T> values)
+        {
+            _values = values;
+        }
+
+        public T Value => Get("");
+
+        public T Get(string? name)
+            => _values[name ?? ""];
+    }
+}

--- a/tests/ACMEServer.Tests/Integration/FakeCertificateIssuer.cs
+++ b/tests/ACMEServer.Tests/Integration/FakeCertificateIssuer.cs
@@ -2,12 +2,13 @@
 using System.Security.Cryptography;
 using Th11s.ACMEServer.Model;
 using Th11s.ACMEServer.Services;
+using Th11s.ACMEServer.Model.Primitives;
 
 namespace Th11s.AcmeServer.Tests.Integration;
 
 internal class FakeCertificateIssuer : ICertificateIssuer
 {
-    public Task<(byte[]? Certificates, AcmeError? Error)> IssueCertificate(string csr, CancellationToken cancellationToken)
+    public Task<(byte[]? Certificates, AcmeError? Error)> IssueCertificate(ProfileName profile, string csr, CancellationToken cancellationToken)
     {
         // Create a self-signed certificate for testing purposes
         using var rsa = RSA.Create(2048);

--- a/tests/ACMEServer.Tests/Services/ProfileSelectorTest.cs
+++ b/tests/ACMEServer.Tests/Services/ProfileSelectorTest.cs
@@ -56,7 +56,7 @@ namespace Th11s.AcmeServer.Tests.Services
             ["device"] = new ProfileConfiguration
             {
                 Name = "device",
-                SupportedIdentifiers = new[] { "persistent-identifier" },
+                SupportedIdentifiers = new[] { "permanent-identifier" },
                 ADCSOptions = new ADCSOptions
                 {
                     CAServer = "http://localhost",
@@ -69,7 +69,7 @@ namespace Th11s.AcmeServer.Tests.Services
             InlineData(["dns", "dns"]),
             InlineData(["ip", "ip"]),
             InlineData(["dns-or-ip", "dns", "ip"]),
-            InlineData(["device", "persistent-identifier"]),
+            InlineData(["device", "permanent-identifier"]),
             ]
         public async Task ValidProfile_Will_Return_Profile(string expecedProfile, params string[] identifierTypes)
         {

--- a/tests/ACMEServer.Tests/Services/ProfileSelectorTest.cs
+++ b/tests/ACMEServer.Tests/Services/ProfileSelectorTest.cs
@@ -21,9 +21,9 @@ namespace Th11s.AcmeServer.Tests.Services
             new ProfileName("device"),
         ];
 
-        IDictionary<string, ProfileDescriptor> _profileDescriptors = new Dictionary<string, ProfileDescriptor>()
+        IDictionary<string, ProfileConfiguration> _profileDescriptors = new Dictionary<string, ProfileConfiguration>()
         {
-            ["dns-or-ip"] = new ProfileDescriptor
+            ["dns-or-ip"] = new ProfileConfiguration
             {
                 Name = "dns-or-ip",
                 SupportedIdentifiers = new[] { "dns", "ip" },
@@ -33,7 +33,7 @@ namespace Th11s.AcmeServer.Tests.Services
                     TemplateName = "WebServer"
                 }
             },
-            ["dns"] = new ProfileDescriptor
+            ["dns"] = new ProfileConfiguration
             {
                 Name = "dns",
                 SupportedIdentifiers = new[] { "dns" },
@@ -43,7 +43,7 @@ namespace Th11s.AcmeServer.Tests.Services
                     TemplateName = "WebServer"
                 }
             },
-            ["ip"] = new ProfileDescriptor
+            ["ip"] = new ProfileConfiguration
             {
                 Name = "ip",
                 SupportedIdentifiers = new[] { "ip" },
@@ -53,7 +53,7 @@ namespace Th11s.AcmeServer.Tests.Services
                     TemplateName = "WebServer"
                 }
             },
-            ["device"] = new ProfileDescriptor
+            ["device"] = new ProfileConfiguration
             {
                 Name = "device",
                 SupportedIdentifiers = new[] { "persistent-identifier" },
@@ -79,7 +79,7 @@ namespace Th11s.AcmeServer.Tests.Services
 
             var sut = new DefaultIssuanceProfileSelector(
                 Options.Create(_profiles),
-                new FakeOptionSnapshot<ProfileDescriptor>(_profileDescriptors)
+                new FakeOptionSnapshot<ProfileConfiguration>(_profileDescriptors)
             );
 
             var profile = await sut.SelectProfile(identifiers, ProfileName.None, default);


### PR DESCRIPTION
Implement issuance profile support.

This PR enables the server to have different configurations depending on the submitted identifiers and later also by selecting an identifier via the client (https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/)
